### PR TITLE
22-DELETE /api/articles/:article_id

### DIFF
--- a/__tests__/articles.test.js
+++ b/__tests__/articles.test.js
@@ -381,12 +381,41 @@ describe("GET /api/articles (pagination)", () => {
         expect(typeof res.body.total_count).toBe("number");
       });
   });
-  test("400: responds with error for invalid limit or page number", () => {
+  test("ERROR - 400: responds with error for invalid limit or page number", () => {
     return request(app)
       .get("/api/articles?limit=banana&p=-1")
       .expect(400)
       .then((res) => {
         expect(res.body.msg).toBe("Invalid pagination query!");
+      });
+  });
+});
+
+describe("DELETE /api/articles/:article_id", () => {
+  test("204: deletes article and associated comments", () => {
+    return request(app)
+      .delete("/api/articles/1")
+      .expect(204)
+      .then(() => {
+        return request(app).get("/api/articles/1").expect(404);
+      });
+  });
+
+  test("ERROR - 400: invalid article_id", () => {
+    return request(app)
+      .delete("/api/articles/not-a-number")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request!");
+      });
+  });
+
+  test("ERROR - 404: non-existent article", () => {
+    return request(app)
+      .delete("/api/articles/9999")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Article not found!");
       });
   });
 });

--- a/endpoints.json
+++ b/endpoints.json
@@ -207,5 +207,12 @@
     "queries": [],
     "exampleRequest": "/api/comments/1",
     "exampleResponse": {}
+  },
+
+  "DELETE /api/articles/:article_id": {
+    "description": "Deletes an article specified by article_id, along with all its associated comments.",
+    "queries": [],
+    "exampleRequest": "/api/articles/1",
+    "exampleResponse": {}
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "seed-prod": "NODE_ENV=production node ./src/db/seeds/run-seed.js",
     "start": "node src/index.js",
     "dev": "NODE_ENV=development nodemon src/index.js",
-    "test": "jest --runInBand",
+    "test": "NODE_ENV=test jest --runInBand",
     "test-seed": "jest seed.test.js"
   },
   "repository": {

--- a/src/app/controllers/articles.controller.js
+++ b/src/app/controllers/articles.controller.js
@@ -4,6 +4,7 @@ const {
   selectAllArticles,
   updateArticleById,
   insertArticle,
+  removeArticleById,
 } = require("../models/articles.model.js");
 const { selectUserByUsername } = require("../models/users.model.js");
 
@@ -91,6 +92,22 @@ exports.patchArticleById = async (req, res, next) => {
     // Apply vote increment and respond with updated article
     const updatedArticle = await updateArticleById(inc_votes, article_id);
     res.status(200).send({ article: updatedArticle });
+  } catch (err) {
+    next(err);
+  }
+};
+
+//! DELETE /api/articles/:article_id
+exports.deleteArticleById = async (req, res, next) => {
+  const { article_id } = req.params;
+
+  if (isNaN(Number(article_id))) {
+    return res.status(400).send({ msg: "Bad request!" });
+  }
+
+  try {
+    await removeArticleById(article_id);
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/src/app/models/articles.model.js
+++ b/src/app/models/articles.model.js
@@ -184,3 +184,16 @@ exports.updateArticleById = async (inc_votes, article_id) => {
   }
   return result.rows[0];
 };
+
+//! DELETE /api/articles/:article_id
+exports.removeArticleById = async (article_id) => {
+  const result = await db.query(
+    `DELETE FROM articles WHERE article_id = $1 RETURNING *;`,
+    [article_id]
+  );
+
+  if (result.rows.length === 0) {
+    throw { status: 404, msg: "Article not found!" };
+  }
+};
+

--- a/src/app/routers/articles.router.js
+++ b/src/app/routers/articles.router.js
@@ -4,6 +4,7 @@ const {
   getAllArticles,
   patchArticleById,
   postArticle,
+  deleteArticleById,
 } = require("../controllers/articles.controller");
 
 const articlesRouter = express.Router();
@@ -19,5 +20,8 @@ articlesRouter.post("/", postArticle);
 
 //! PATCH /api/articles/:article_id
 articlesRouter.patch("/:article_id", patchArticleById);
+
+//! DELETE /api/articles/:article_id
+articlesRouter.delete("/:article_id", deleteArticleById);
 
 module.exports = articlesRouter;


### PR DESCRIPTION
- Added DELETE /api/articles/:article_id endpoint
- Associated comments auto deleted via ON DELETE CASCADE on the foreign key constraint
- Tests - added 1 happy, 2 sad paths. 
- Added to endpoints.json documentation